### PR TITLE
This fixes #1245, premature routing to marathon

### DIFF
--- a/provider/marathon.go
+++ b/provider/marathon.go
@@ -256,13 +256,14 @@ func (provider *Marathon) taskFilter(task marathon.Task, applications *marathon.
 
 	//filter healthchecks
 	if application.HasHealthChecks() {
-		if task.HasHealthCheckResults() {
-			for _, healthcheck := range task.HealthCheckResults {
-				// found one bad healthcheck, return false
-				if !healthcheck.Alive {
-					log.Debugf("Filtering marathon task %s with bad healthcheck", task.AppID)
-					return false
-				}
+		if !task.HasHealthCheckResults() {
+			return false
+		}
+		for _, healthcheck := range task.HealthCheckResults {
+			// found one bad healthcheck, return false
+			if !healthcheck.Alive {
+				log.Debugf("Filtering marathon task %s with bad healthcheck", task.AppID)
+				return false
 			}
 		}
 	}


### PR DESCRIPTION
After this fix, traefik will not route traffic to marathon jobs that
have healthchecks that have not run yet.

<!--
How to write a good pull request?

Read https://github.com/containous/traefik/blob/master/.github/how-to-write-a-good-pull-request.md.

And the contributing guide: https://github.com/containous/traefik/blob/master/.github/CONTRIBUTING.md.
-->

### Description

<!--
Briefly describe the pull request in a few paragraphs.
-->